### PR TITLE
Update exports for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.cjs",
   "type": "module",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.es.js",
     "require": "./dist/index.cjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yettoapp/lezer-jsonc",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "lezer-based JSONC grammar",
   "main": "dist/index.cjs",
   "type": "module",


### PR DESCRIPTION
The reasoning behind this is that TS cannot discover types that are now explicitly exported in `package.json`, which leads to treating the package as `any`.